### PR TITLE
Community page and library pages updated

### DIFF
--- a/hugo_themes/content/community/_index.md
+++ b/hugo_themes/content/community/_index.md
@@ -14,7 +14,7 @@ header:
   image: ""
 ---
 
-The SBOL GitHub repository can be accessed [here](https://github.com/SynBioDex/Community-Media).
+The SBOL GitHub repository can be accessed [here](https://github.com/SynBioDex).
 
 The SBOL community works actively on the SBOL data model and visual standard, participates in online discussions, and meets semi-annually.  We represent over 170+ members from 17 different countries, 42 institutions, and 28 different industries. Many of our members are also actively involved in other standards communities, like the Systems Biology Markup Language (SBML) and Systems Biology Graphical Notation (SBGN).
 

--- a/hugo_themes/content/community/_index.md
+++ b/hugo_themes/content/community/_index.md
@@ -19,7 +19,7 @@ The SBOL GitHub repository can be accessed [here](https://github.com/SynBioDex/C
 The SBOL community works actively on the SBOL data model and visual standard, participates in online discussions, and meets semi-annually.  We represent over 170+ members from 17 different countries, 42 institutions, and 28 different industries. Many of our members are also actively involved in other standards communities, like the Systems Biology Markup Language (SBML) and Systems Biology Graphical Notation (SBGN).
 
 
-To join our growing community, contact the SBOL Editors at sbol-editors@googlegroups.com.
+To join our growing community, contact the SBOL Editors [here](https://docs.google.com/forms/d/12OfLZ05guthLVvdapwxHWq7JSBaTPr_O3QXIeiGDfPU/edit).
 
 ### Members
 

--- a/hugo_themes/content/libraries/cpp/index.md
+++ b/hugo_themes/content/libraries/cpp/index.md
@@ -52,4 +52,6 @@ slides: ""
 
 libSBOL provides the core C/C++ interfaces and their implementation for the Synthetic Biology Open Language (SBOL). The current version of pySBOL implements SBOL Core Specification 2.2.0. The library provides an API to work with SBOL objects and to validate the correctness of SBOL 2 documents. Version 2.3.0 of the libSBOL library provides an API to construct designs and to read and write SBOL version 2.2.0 XML/RDF files. libSBOL is made freely available under the Apache 2.0 license.
 
+The above mentioned version is the current stable version of libSBOL. 
+
 <b>Cite</b>: B. Bartley, K. Choi, M. Samineni, Z. Zundel, T. Nguyen, C. Myers, and H. Sauro.pySBOL: A Python Package for Genetic Design Automation and Standardization. ACS Synthetic Biology, (2018). doi:10.1021/acssynbio.8b00336.

--- a/hugo_themes/content/libraries/fsharp/index.md
+++ b/hugo_themes/content/libraries/fsharp/index.md
@@ -17,7 +17,11 @@ links:
   icon_pack: fab
   name: Github
   url: https://github.com/SynBioDex/fSBOL
-# - icon: book
+- icon: bug
+  icon_pack: fas
+  name: Bug & Feature Report
+  url: https://github.com/SynBioDex/fSBOL/issues
+
 #   icon_pack: fab
 #   name: Science Publication
 #   url: https://science.sciencemag.org/content/352/6281/aac7341
@@ -38,4 +42,4 @@ url_video: ""
 slides: ""
 ---
 
-fSBOL is made freely available under the MIT license
+fSBOL is made freely available under the MIT license. It is an F# implementation of the Synthetic Biology Open Language (SBOL) Data Model.

--- a/hugo_themes/content/libraries/java/index.md
+++ b/hugo_themes/content/libraries/java/index.md
@@ -55,5 +55,6 @@ slides: ""
 
 libSBOLj provides the core Java interfaces and their implementation for the Synthetic Biology Open Language (SBOL). The current version of libSBOLj implements SBOL Core Specification 2.3.0. The library provides an API to work with SBOL objects, the functionality to read GenBank, FASTA, and SBOL version 1 and 2 documents as XML/RDF files, to write GenBank, FASTA, and SBOL version 1 and 2 documents, and to validate the correctness of SBOL 2 documents. libSBOLj is made freely available under the Apache 2.0 license.
 
+This is the current stable version of libSBOLj.
 
 <b>Cite: </b> Z. Zhang, T. Nguyen, N. Roehner, G. Misirli, M. Pocock, E. Oberortner, M. Samineni, Z. Zundel, J. Beal, K. Clancy, A. Wipat, C. Myers. libSBOLj 2.0: A Java Library to Support SBOL 2.0. IEEE Life Sciences Letters 1, 34-37 (2016). doi:10.1109/LLS.2016.2546546.

--- a/hugo_themes/content/libraries/javascript/index.md
+++ b/hugo_themes/content/libraries/javascript/index.md
@@ -16,7 +16,7 @@ links:
 - icon: github
   icon_pack: fab
   name: Github
-  url: https://github.com/SynBioDex/libSBOLj
+  url: https://github.com/SynBioDex/sboljs
 - icon: file-alt
   icon_pack: fas
   name: Overview
@@ -24,19 +24,19 @@ links:
 - icon: edge
   icon_pack: fab
   name: API & Documentation
-  url: http://synbiodex.github.io/libSBOLj/docs/javadocs
+  url: http://synbiodex.github.io/sboljs/
 - icon: tools
   icon_pack: fas
   name: Installation
-  url: http://synbiodex.github.io/libSBOL/installation.html
+  url: https://github.com/SynBioDex/sboljs/blob/master/README.md
 - icon: code
   icon_pack: fas
   name: Release (v 2.4.0)
-  url: https://github.com/SynBioDex/libSBOLj/releases
+  url: https://github.com/SynBioDex/sboljs/releases
 - icon: bug
   icon_pack: fas
   name: Bug & Feature Report
-  url: https://github.com/SynBioDex/libSBOLj/issues
+  url: https://github.com/SynBioDex/sboljs/issues
 - icon: book
   icon_pack: fas
   name: CRISPR Circuit Example

--- a/hugo_themes/content/libraries/python/index.md
+++ b/hugo_themes/content/libraries/python/index.md
@@ -31,12 +31,13 @@ links:
   url: https://pysbol2.readthedocs.io/en/latest/installation.html
 - icon: code
   icon_pack: fas
-  name: Release (v 2.3.0)
-  url: https://github.com/SynBioDex/pySBOL/releases/tag/2.3.0
+  name: Release (v 1.1.0)
+  url: https://github.com/SynBioDex/pySBOL2/releases/tag/v1.1
 - icon: bug
   icon_pack: fas
   name: Bug & Feature Report
-  url: https://github.com/SynBioDex/pysbol/issues
+  url: https://github.com/SynBioDex/pySBOL2/issues
+
 - icon: book
   icon_pack: fas
   name: CRISPR Circuit Example
@@ -55,6 +56,9 @@ slides: ""
 ---
 
 pySBOL provides Python interfaces and their implementation for Synthetic Biology Open Language (SBOL). The current version of pySBOL implements SBOL Core Specification 2.2.0. The library provides an API to work with SBOL objects, the functionality to read GenBank, FASTA, and SBOL version 1 and 2 documents as XML/RDF files, to write GenBank, FASTA, and SBOL version 1 and 2 documents, and to validate the correctness of SBOL 2 documents. This is a Python binding for C/C++ based libSBOL. Currently, pySBOL supports Python version 2.7 and 3.6 only. pySBOL is made freely available under the Apache 2.0 license.
+
+The current stable version is pySBOL2 (listed above). The repository of beta version of pySBOL3 library can be accessed [here](https://github.com/SynBioDex/pySBOL3).
+
 
 
 <b>Cite: </b> B. Bartley, K. Choi, M. Samineni, Z. Zundel, T. Nguyen, C. Myers, and H. Sauro.pySBOL: A Python Package for Genetic Design Automation and Standardization. ACS Synthetic Biology, (2018). doi:10.1021/acssynbio.8b00336.


### PR DESCRIPTION
Community page and libraries pages are updated. All the links of SBOLjs library were wrongly pointing to libSBOLj library. This has been corrected. However, the document of CRISPR example in SBOLjs is appear to be missing under /docs/ directory.