### PR TITLE
Fix broken links to external tools

### DIFF
--- a/content/applications/protobiocompiler/index.md
+++ b/content/applications/protobiocompiler/index.md
@@ -15,7 +15,7 @@ links:
 - icon: edge
   icon_pack: fab
   name: Link
-  url: https://synbiotools.bbn.com/
+  url: https://web.archive.org/web/20200528234504/https://synbiotools.bbn.com/
 
 # Slides (optional).
 #   Associate this project with Markdown slides.

--- a/content/applications/protobiocompiler/index.md
+++ b/content/applications/protobiocompiler/index.md
@@ -11,12 +11,6 @@ image:
   # caption: Photo by rawpixel on Unsplash
   focal_point: Smart
 
-links:
-- icon: edge
-  icon_pack: fab
-  name: Link
-  url: https://web.archive.org/web/20200528234504/https://synbiotools.bbn.com/
-
 # Slides (optional).
 #   Associate this project with Markdown slides.
 #   Simply enter your slide deck's filename without extension.

--- a/content/applications/sbolgenbank/index.md
+++ b/content/applications/sbolgenbank/index.md
@@ -15,7 +15,7 @@ links:
 - icon: edge
   icon_pack: fab
   name: Link
-  url: https://j5.jbei.org/bin/sbol_converter_entry_form.pl
+  url: https://web.archive.org/web/20190205183146/https://j5.jbei.org/bin/sbol_converter_entry_form.pl
 
 # Slides (optional).
 #   Associate this project with Markdown slides.

--- a/content/applications/sbolgenbank/index.md
+++ b/content/applications/sbolgenbank/index.md
@@ -15,7 +15,7 @@ links:
 - icon: edge
   icon_pack: fab
   name: Link
-  url: https://web.archive.org/web/20190205183146/https://j5.jbei.org/bin/sbol_converter_entry_form.pl
+  url: https://j5.jbei.org/
 
 # Slides (optional).
 #   Associate this project with Markdown slides.

--- a/content/applications/sbolme/index.md
+++ b/content/applications/sbolme/index.md
@@ -15,7 +15,7 @@ links:
 - icon: edge
   icon_pack: fab
   name: Link
-  url: http://www.cbrc.kaust.edu.sa/sbolme/
+  url: https://web.archive.org/web/20201128054240/https://www.cbrc.kaust.edu.sa/sbolme//
 
 # Slides (optional).
 #   Associate this project with Markdown slides.

--- a/content/applications/shortbol/index.md
+++ b/content/applications/shortbol/index.md
@@ -19,7 +19,7 @@ links:
 - icon: laptop
   icon_pack: fas
   name: Demo
-  url: http://shortbol.org/sandbox.html
+  url: http://shortbol.org/
 url_code: ""
 url_pdf: ""
 url_slides: ""

--- a/content/publication/grunberg-bbf-2009/cite.bib
+++ b/content/publication/grunberg-bbf-2009/cite.bib
@@ -1,16 +1,16 @@
 @article{grunberg_bbf_2009,
- abstract = {This Request for Comments (RFC) suggests a framework for the description,  
-exchange and interlinking of Synthetic Biology data. The framework would  
-create an open process for the evolution and “rolling” standardization of data  
-models. It describes how data and data models are to be published, how they  
-are exchanged and integrated between diﬀerent parties, and how they can be  
-extended, corrected and interlinked in a decentralized fashion. These goals  
-are achieved by embracing the RDF (Resource Description Framework), a set  
-of W3C standards. A one-sentence summary of this proposal would there-  
-fore be: “Use RDF according to the W3C standards.” The PoBoL pro ject  
-(Provisional BioBrick Ontology Language, http://pobol.org) is based on  
-this idea.  
-This RFC does not describe a data model per se but only outlines a  
+ abstract = {This Request for Comments (RFC) suggests a framework for the description,
+exchange and interlinking of Synthetic Biology data. The framework would
+create an open process for the evolution and “rolling” standardization of data
+models. It describes how data and data models are to be published, how they
+are exchanged and integrated between diﬀerent parties, and how they can be
+extended, corrected and interlinked in a decentralized fashion. These goals
+are achieved by embracing the RDF (Resource Description Framework), a set
+of W3C standards. A one-sentence summary of this proposal would there-
+fore be: “Use RDF according to the W3C standards.” The PoBoL pro ject
+(Provisional BioBrick Ontology Language, https://web.archive.org/web/20091216100340/http://pobol.org/) is based on
+this idea.
+This RFC does not describe a data model per se but only outlines a
 possible architecture and rules of data exchange.},
  author = {Grunberg, Raik},
  date = {2009-04-24},

--- a/content/publication/grunberg-bbf-2009/index.md
+++ b/content/publication/grunberg-bbf-2009/index.md
@@ -39,7 +39,7 @@ abstract: 'This Request for Comments (RFC) suggests a framework for the descript
   in a decentralized fashion. These goals   are achieved by embracing the RDF (Resource
   Description Framework), a set   of W3C standards. A one-sentence summary of this
   proposal would there-   fore be: “Use RDF according to the W3C standards.” The PoBoL
-  pro ject   (Provisional BioBrick Ontology Language, http://pobol.org) is based on   this
+  pro ject   (Provisional BioBrick Ontology Language, https://web.archive.org/web/20091216100340/http://pobol.org/) is based on   this
   idea.   This RFC does not describe a data model per se but only outlines a   possible
   architecture and rules of data exchange.'
 publication: ''

--- a/content/publication/kuwahara-sbolme-2017/cite.bib
+++ b/content/publication/kuwahara-sbolme-2017/cite.bib
@@ -1,5 +1,5 @@
 @article{kuwahara_sbolme_2017,
- abstract = {The Synthetic Biology Open Language (SBOL) is a community-driven open language to promote standardization in synthetic biology. To support the use of SBOL in metabolic engineering, we developed SBOLme, the first open-access repository of SBOL 2-compliant biochemical parts for a wide range of metabolic engineering applications. The URL of our repository is http://www.cbrc.kaust.edu.sa/sbolme.},
+ abstract = {The Synthetic Biology Open Language (SBOL) is a community-driven open language to promote standardization in synthetic biology. To support the use of SBOL in metabolic engineering, we developed SBOLme, the first open-access repository of SBOL 2-compliant biochemical parts for a wide range of metabolic engineering applications. The URL of our repository is https://web.archive.org/web/20201128054240/https://www.cbrc.kaust.edu.sa/sbolme/.},
  author = {Kuwahara, Hiroyuki and Cui, Xuefeng and Umarov, Ramzan and Grünberg, Raik and Myers, Chris J. and Gao, Xin},
  date = {2017-04-21},
  doi = {10.1021/acssynbio.6b00278},

--- a/content/publication/kuwahara-sbolme-2017/index.md
+++ b/content/publication/kuwahara-sbolme-2017/index.md
@@ -39,7 +39,7 @@ abstract: The Synthetic Biology Open Language (SBOL) is a community-driven open 
   to promote standardization in synthetic biology. To support the use of SBOL in metabolic
   engineering, we developed SBOLme, the first open-access repository of SBOL 2-compliant
   biochemical parts for a wide range of metabolic engineering applications. The URL
-  of our repository is http://www.cbrc.kaust.edu.sa/sbolme.
+  of our repository is https://web.archive.org/web/20201128054240/https://www.cbrc.kaust.edu.sa/sbolme/.
 publication: ''
 url_pdf: https://doi.org/10.1021/acssynbio.6b00278
 doi: 10.1021/acssynbio.6b00278


### PR DESCRIPTION
Where there is no current working link, link to archived page on archive.org instead.