### PR TITLE
Fix several broken wp-content links

### DIFF
--- a/content/event/2017/iwbda/2017-08-15-iwbda-2017.md
+++ b/content/event/2017/iwbda/2017-08-15-iwbda-2017.md
@@ -9,7 +9,7 @@ permalink: /iwbda-2017/
 categories:
   - Announcements
 ---
-[<img src="http://aries.ncl.ac.uk/sbol/wp-content/uploads/2017/06/iwbda2017_small.png" alt="" width="50%" height="50%" />](http://www.iwbdaconf.org/2017/program/)
+[<img src="https://www.iwbdaconf.org/2017/images/iwbda2017_small.png" alt="" width="50%" height="50%" />](http://www.iwbdaconf.org/2017/program/)
 
 Was held at the University of Pittsburgh on August 7th &#8211; 10th.
 

--- a/content/event/2017/iwbda/index.md
+++ b/content/event/2017/iwbda/index.md
@@ -9,7 +9,7 @@ permalink: /iwbda2017/
 categories:
   - Announcements
 ---
-<img src="http://sbolstandard.org/wp-content/uploads/2017/06/iwbda2017_small.png" alt="" width="1200" height="424" class="alignnone size-full wp-image-2320" />
+<img src="https://www.iwbdaconf.org/2017/images/iwbda2017_small.png" alt="" width="1200" height="424" class="alignnone size-full wp-image-2320" />
 
 ## Location: University of Pittsburgh, PA.  
 Date: August 8th – 11th, 2017  

--- a/content/event/2018/iwbda/index.md
+++ b/content/event/2018/iwbda/index.md
@@ -15,15 +15,15 @@ There will be a one-day workshop to introduce software developers to SBOL on Aug
 
 The preliminary program (subject to change) is as follows:
 
-  * 09:00-9:30 [Introduction to SBOL](http://sbolstandard.org/wp-content/uploads/2018/06/SBOL-IWBDA-2018.pdf) &#8211; Jake Beal
-  * 9:30-10:00 [Linking Design and Experimental Information](http://sbolstandard.org/wp-content/uploads/2018/06/SBOL-IWBDA-2018.pdf) &#8211; Jake Beal
-  * 10:00-11:00 [Introduction to the SBOL2 Data Model, the Java Library (libSBOLj), and the Javascript Library (sboljs)](http://sbolstandard.org/wp-content/uploads/2018/06/SBOLWorkshop2018.pdf) &#8211; Chris Myers
+  * 09:00-9:30 [Introduction to SBOL](https://github.com/SynBioDex/Community-Media/raw/master/2018/IWBDA18/SBOL-IWBDA-2018.pptx) &#8211; Jake Beal
+  * 9:30-10:00 [Linking Design and Experimental Information](https://github.com/SynBioDex/Community-Media/raw/master/2018/IWBDA18/SBOL-IWBDA-2018.pptx) &#8211; Jake Beal
+  * 10:00-11:00 [Introduction to the SBOL2 Data Model, the Java Library (libSBOLj), and the Javascript Library (sboljs)](https://github.com/SynBioDex/Community-Media/blob/master/2018/IWBDA18/SBOLWorkshop2018_java_js.pdf) &#8211; Chris Myers
   * 11:00-11:30 Coffee
-  * 11:30-12:00 [C++ and Python Libraries](http://sbolstandard.org/wp-content/uploads/2018/06/Intro2pySBOL.pdf) &#8211; Bryan Bartley
+  * 11:30-12:00 [C++ and Python Libraries](https://github.com/SynBioDex/Community-Media/raw/master/2018/IWBDA18/Intro2pySBOL.pptx) &#8211; Bryan Bartley
   * 12:00-13:00 Lunch
   * 13:00-15:30 [Hands-on Tutorial](https://github.com/SynBioDex/Community-Media/tree/master/2018/IWBDA18/workshop) &#8211; Zach Palchick
   * 15:30-16:00 Coffee
-  * 16:00-17:00 [Panel Discussion](http://sbolstandard.org/wp-content/uploads/2018/06/SBOL@IWBDA-18-Panel-Discussion.pdf) 
+  * 16:00-17:00 [Panel Discussion](https://github.com/SynBioDex/Community-Media/blob/master/2018/IWBDA18/SBOL%40IWBDA-18%20-%20Panel%20Discussion.pdf) 
       * Moderator: Ernst Oberortner
       * Panelists: Bryan Bartley, Curtis Madsen, Chris Myers, Nicholas Roehner
 


### PR DESCRIPTION
This is a partial fix for #174. This fixes a number of broken `wp-content` links. #175 fixes another.

At least one broken link will remain.