### PR TITLE
Make SBOL Visual glyphs larger

### DIFF
--- a/content/visual-glyphs/_index.md
+++ b/content/visual-glyphs/_index.md
@@ -29,17 +29,17 @@ Look at this {{% staticref "docs/SBOL-Visual-2.1-Quickstart.pdf" "newtab" %}}qui
 Zip files containing images of the glyphs as PDF, PNG or SVG files can be downloaded from the [Releases page](https://github.com/SynBioDex/SBOL-visual/releases) of the SBOL Visual repository on GitHub.
 
 <a href="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Sequence%20Features.png">
-<img src="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Sequence%20Features.png" width="470" />
+<img src="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Sequence%20Features.png"/>
 </a>
 
 <a href="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Molecular%20Species.png">
-<img src="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Molecular%20Species.png" width="470" />
+<img src="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Molecular%20Species.png"/>
 </a>
 
 <a href="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Interactions.png">
-<img src="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Interactions.png" width="470" />
+<img src="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Interactions.png"/>
 </a>
 
 <a href="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Interaction%20Nodes.png">
-<img src="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Interaction%20Nodes.png" width="470" />
+<img src="https://raw.githubusercontent.com/SynBioDex/SBOL-visual/master/sampler/Interaction%20Nodes.png"/>
 </a>


### PR DESCRIPTION
Make the SBOL Visual glyphs easier to read by allowing them to be larger on the page.

Closes #136 