### PR TITLE
Remove dead content

### DIFF
--- a/content/DataModel-Specification/_index.md
+++ b/content/DataModel-Specification/_index.md
@@ -15,31 +15,9 @@ header:
 ---
 
 [Report an Issue with the Current SBOL Specification](https://github.com/SynBioDex/SBOL-specification/issues)
-
 <!--
 
-Everything below here is commented out via the HTML comment
-above. Leave this here until all of this data is migrated to
-individual pages. Then this content can be deleted.
+The body of this page is filled in with the `version-X.Y.Z.md` pages
+in this directory using the template found at `/layouts/DataModel-Specification`
 
-___
-
-| **3.x.x Release**  | [Library Implementation]({{< relref "libraries" >}})  |   |
-|---|---|---|
-| **[3.0.1](/datamodel-3.0.1)** <br> An extension of version 3.0.0 data model to allow flexibility and extendibility of the following: move declaration of SBOL namespace from serialization to identifiers, change all identifiers.org URLs to short form, add serialization recommendation, use best practices in URI examples, change of logos, added compact validation rules, add extension of SBOL classes to extension options, improve complementary standards section, explain closure assumptions and document composition implications, use RDF cardinality terminology, add combinatorial derivation & validation rules amongst other fixes and updates. | {{% staticref "docs/SBOL3.0.1.pdf" "newtab" %}}Specification{{% /staticref %}}  |   |
-| **3.0.0** <br> Condenses and simplifies previous versions of SBOL, separates sequence features from part/sub-part relationships, renames ComponentDefinition/Component to Component/SubComponent, merges Component and Module classes, ensuring consistency between data model and ontology terms, extends the means to define and reference SubComponents, refines requirements on object URIs, enables graph-based serialization, moves Systems Biology Ontology (SBO) for Component types, makes all sequence associations explicit, makes interfaces explicit, generalizes SequenceConstraints into a general structural Constraint class, and expands the set of allowed constraints.| {{% staticref "docs/SBOL3.0.0.pdf" "newtab" %}}Specification{{% /staticref %}}  | [Cite](https://www.degruyter.com/view/journals/jib/ahead-of-print/article-10.1515-jib-2020-0017/article-10.1515-jib-2020-0017.xml)  |
-
-| **2.x.x Release** | [Library Implementation]({{< relref "libraries" >}})  |  |
-|---|---|---|
-| **2.3.0** <br> Includes means of succinctly representing sequence modifications, an extension to support organization and attachment of experimental data, and an extension for describing numerical parameters of design elements. The new version also includes specifying types of synthetic biology activities, unambiguous locations for sequences with multiple encodings, and refinement of a number of validation rules. | {{% staticref "docs/SBOL2.3.0.pdf" "newtab" %}}Specification{{% /staticref %}} | [Cite](https://www.degruyter.com/view/journals/jib/16/2/article-20190025.xml) |
-| **2.2.1** <br> Clarification on ontology terms on roles for proteins and small molecules, refining a number of validation rules, and illustrating a design for combinatorial derivations using Prov-O. | {{% staticref "docs/SBOL-data-model-2.2.1.pdf" "newtab" %}}Specification{{% /staticref %}} |  |
-| **[2.2.0](/datamodel-2.2.0)** <br> Introduces new classes for representing combinatorial genetic designs, physical implementations of genetic designs, and attachments to external files. It also adds best practices for using existing classes to encode provenance for the Design-Build-Test-Learn cycle. | {{% staticref "docs/BBF-RFC114-SBOL2.2.0.pdf" "newtab" %}}Specification{{% /staticref %}} | [Cite](https://www.degruyter.com/view/journals/jib/15/1/article-20180001.xml) |
-| **2.1.0** <br> A backwards-compatible release extending the data model and updating ontology terms and best practices. | {{% staticref "docs/BBF-RFC112-SBOL2.1.0.pdf" "newtab" %}}Specification{{% /staticref %}} | [Cite](https://www.degruyter.com/view/journals/jib/13/3/article-p30.xml) |
-| **2.0.1** <br> An updated version of SBOL 2.0 data model to refine validation rules. | {{% staticref "docs/SBOLv2.0.1.pdf" "newtab" %}}Specification{{% /staticref %}} |  |
-| **2.0.0** <br> An extension of version 1.1 data model to allow flexibility and extendibility of the following: Represent non-DNA structural components of a biological design; Describe the behavioral aspects of a biological design; Associate structure and function to a design; Support rich annotation of biological designs. | {{% staticref "docs/BBF-RFC108-SBOL2.0.pdf" "newtab" %}}Specification{{% /staticref %}} | [Cite](https://www.degruyter.com/view/journals/jib/12/2/article-p902.xml) |
-
-| **1.x.x Release** |  |  |
-|---|---|---|
-| **1.1.0** <br> Version 1.1.0 of the SBOL core data model is limited to the description of discrete segments of DNA, called DNA components. To remove ambiguity when specifying the design of synthetic DNA, the information about DNA components is structured. DNA components described using the SBOL core data model may have an associated DNA sequence, or may be left as abstract descriptions. This flexibility allows for the description of DNA component designs which have not yet been realized, as well as those which are specific implementations of that design. | {{% staticref "docs/BBFRFC87.pdf" "newtab" %}}Specification{{% /staticref %}} | [Cite](https://www.nature.com/articles/nbt.2891) |
-| **1.0.0** <br> Define the vocabulary that contain a set of preferred terms and the core data model composed of a common computational representation, to enable the electronic exchange of information describing DNA components used in synthetic biology. | {{% staticref "docs/SBOLv1.0.0.pdf" "newtab" %}}Specification{{% /staticref %}} | [Cite](https://www.nature.com/articles/nbt.2891) |
 -->


### PR DESCRIPTION
The original content of the Data Model Specification page had been commented out to instead use the Data Model layout. The layout is working fine, so remove the old table and leave a comment explaining where the content lives and how it is generated.