### PR TITLE
update workerflows to use more recent worker versions

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -8,7 +8,7 @@ on:
     
 jobs:
   check-links:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     
       - name: Install

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
"The Ubuntu 18.04 Actions runner image started our deprecation process on 8/8/22 and will be fully unsupported by 4/1/23" 

https://github.com/actions/runner-images/issues/6002