### PR TITLE
Add Slack link to home page

### DIFF
--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -48,6 +48,9 @@ social:
 #- icon: google-scholar
 #  icon_pack: ai
 #  link: https://scholar.google.co.uk/citations?user=sIwtMXoAAAAJ
+- icon: slack
+  icon_pack: fab
+  link: https://join.slack.com/t/sbol-standard/shared_invite/zt-1xjsvsiy8-gFM3dAAju~JpBQDswDWHYg
 - icon: github
   icon_pack: fab
   link: https://github.com/SynBioDex


### PR DESCRIPTION
This PR adds a slack icon and link to the home page. I put it first in the list of Slack, GitHub, Twitter, and YouTube. It is easy to change the order so please speak up if you have thoughts.

Closes #232 